### PR TITLE
add page object models and common utils ported from Monterey project

### DIFF
--- a/common-utils/common-UI/common-UI.js
+++ b/common-utils/common-UI/common-UI.js
@@ -1,0 +1,246 @@
+export class CommonUI {
+  constructor(inputTestRunner) {
+    this.testRunner = inputTestRunner;
+  }
+
+  /**
+   * Generate a selector string for a filter based on its field attribute.
+   * CAUTION: retrieving the elements associated with the returned selector string 
+   * may produce multiple filters if they all correspond to the same field attribute 
+   * @param {String} field Field attribute value of the filter
+   * @returns {String}
+   */
+  _generateFilterSearchString(field) {
+    return `[data-test-subj~="filter"][data-test-subj~="filter-key-${field}"]`
+  }
+
+  /**
+   * Sets the page date range
+   * @param {String} start Start datetime to set
+   * @param {String} end  End datetime to set
+   */
+  setDateRange(start, end) {
+    this.testRunner.get('[data-test-subj="superDatePickerShowDatesButton"]').should('be.visible').click()
+
+    this.testRunner.get('[data-test-subj="superDatePickerendDatePopoverButton"]').should('be.visible').click()
+    this.testRunner.get('[data-test-subj="superDatePickerAbsoluteTab"]').should('be.visible').click()
+    this.testRunner.get('[data-test-subj="superDatePickerAbsoluteDateInput"]').should('be.visible').type(`{selectall}${start}`)
+    this.testRunner.get('[data-test-subj="superDatePickerendDatePopoverButton"]').should('be.visible').click()
+    this.testRunner.get('[data-test-subj="superDatePickerAbsoluteTab"]').should('not.exist')
+
+    this.testRunner.get('[data-test-subj="superDatePickerstartDatePopoverButton"]').should('be.visible').click()
+    this.testRunner.get('[data-test-subj="superDatePickerAbsoluteTab"]').should('be.visible').click()
+    this.testRunner.get('[data-test-subj="superDatePickerAbsoluteDateInput"]').should('be.visible').type(`{selectall}${end}`)
+    this.testRunner.get('[data-test-subj="superDatePickerstartDatePopoverButton"]').should('be.visible').click()
+
+    this.testRunner.get('[data-test-subj="querySubmitButton"]').should('be.visible').click()
+  }
+
+  /**
+   * Attempts to add a specified filter to a dashboard, retrying by reopening the filter window
+   * @param {String} field Field value to select
+   * @param {String} operator Operator value to select
+   * @param {String} value Value field input
+   */
+  addFilterRetryFull(field, operator, value = null, maxRetries = 3) {
+    // Try and select the desire combo box option
+    const selectComboBoxInput = (selector, keyword) => {
+      this.testRunner.get(`[data-test-subj="${selector}"]`).find('[data-test-subj="comboBoxInput"]').trigger('focus').type(`{selectall}{backspace}${keyword}`)
+      this.testRunner.get(`[data-test-subj="comboBoxOptionsList ${selector}-optionsList"]`).find(`[title="${keyword}"]`).trigger('click', { force: true })
+    }
+
+    // Attempt up to three times to select the desired field and operator options and input the value (if applicable)
+    const tryToAddFilter = (field, operator, value = null, retry = 0) => {
+      this.testRunner.get('[data-test-subj="addFilter"]').click({ scrollBehavior: 'center' }).then(() => {
+        selectComboBoxInput('filterFieldSuggestionList', field)
+        this.testRunner.get('[data-test-subj="filterFieldSuggestionList"]').then(($field) => {
+          const cls = $field.attr('class')
+          if (cls.includes('euiComboBox-isInvalid') && retry < maxRetries) {
+            this.testRunner.get('[data-test-subj="cancelSaveFilter"]').click()
+            tryToAddFilter(field, operator, value, retry + 1)
+          } else {
+            selectComboBoxInput('filterOperatorList', operator)
+            this.testRunner.get('[data-test-subj="filterOperatorList"]').then(($operator) => {
+              const cls = $operator.attr('class')
+              if (cls.includes('euiComboBox-isInvalid') && retry < maxRetries) {
+                this.testRunner.get('[data-test-subj="cancelSaveFilter"]').click()
+                tryToAddFilter(field, operator, value, retry + 1)
+              } else {
+                if (value !== null) {
+                  this.testRunner.get('[data-test-subj="filterParams"]').find('input').type(value)
+                }
+                this.testRunner.get('[data-test-subj="saveFilter"]').click()
+                this.testRunner.get(this._generateFilterSearchString(field)).last().should('be.visible')
+              }
+            })
+          }
+        })
+      })
+    }
+    tryToAddFilter(field, operator, value)
+  }
+
+  /**
+   * Attempts to add a specified filter, retrying by reselecting the failed option
+   * @param {String} field Field value to select
+   * @param {String} operator Operator value to select
+   * @param {String} value Value field input
+   */
+  addFilterRetrySelection(field, operator, value = null, maxRetries = 3) {
+    const selectComboBoxInput = (selector, keyword, retry = 0) => {
+      this.testRunner.get(`[data-test-subj="${selector}"]`).find('[data-test-subj="comboBoxInput"]').trigger('focus').type(`{selectall}{backspace}${keyword}`)
+      this.testRunner.get(`[data-test-subj="comboBoxOptionsList ${selector}-optionsList"]`).find(`[title="${keyword}"]`).trigger('click', { force: true })
+      this.testRunner.get(`[data-test-subj="${selector}"]`).then(($box) => {
+        const cls = $box.attr('class')
+        if (cls.includes('euiComboBox-isInvalid') && retry < maxRetries) {
+          this.testRunner.wrap($box).find('[data-test-subj="comboBoxInput"]').type('{selectall}{backspace}')
+          this.testRunner.wrap($box).find('[data-test-subj="comboBoxToggleListButton"]').click()
+          selectComboBoxInput(selector, keyword, retry + 1)
+        }
+      })
+    }
+
+    this.testRunner.get('[data-test-subj="addFilter"]').click().then(() => {
+      selectComboBoxInput('filterFieldSuggestionList', field)
+      selectComboBoxInput('filterOperatorList', operator)
+    })
+
+    if (value != null) {
+      this.testRunner.get('[data-test-subj="filterParams"]').find('input').type(value)
+    }
+
+    this.testRunner.get('[data-test-subj="saveFilter"]').click()
+    this.testRunner.get(this._generateFilterSearchString(field)).last().should('be.visible')
+  }
+
+  /**
+   * Pins a filter with a specified field attribute and an optional
+   * index number representing which position the desired filter is located at
+   * out of multiple filters with the same field attribute value
+   * @param {String} field Field attribute value to search for
+   * @param {Number} index Optional index position from an array of filter elements
+   */
+  pinFilter(field, index=0) {
+    this.testRunner.get(this._generateFilterSearchString(field)).eq(index).click()
+    this.testRunner.get('[data-test-subj="pinFilter"]').click()
+  }
+
+  /**
+   * Removes a filter with a specified field attribute and an optional
+   * index number representing which position the desired filter is located at
+   * out of multiple filters with the same field attribute value
+   * @param {String} field Field attribute value to search for
+   * @param {Number} index Optional index position from an array of filter elements
+   */
+  removeFilter(field, index=0) {
+    this.testRunner.get(this._generateFilterSearchString(field)).then(($filters) => {
+      const numFilters = $filters.length
+      cy.wrap($filters).eq(index).click()
+      this.testRunner.get('[data-test-subj="deleteFilter"]').click()
+      if(numFilters - 1 == 0){
+        this.testRunner.get(this._generateFilterSearchString(field)).should('not.exist')
+      }
+      else {
+        this.testRunner.get(this._generateFilterSearchString(field)).should('be.length', numFilter - 1)
+      }
+    })
+  }
+
+  /**
+   * Removes all filters from the page
+   */
+  removeAllFilters() {
+    this.testRunner.get('[data-test-subj="showFilterActions"]').click()
+    this.testRunner.get('[data-test-subj="removeAllFilters"]').click()
+  }
+
+  /**
+   * Filters a pie chart visualization by a specified slice
+   * @param {String} name Name of the pie chart slice to filter on
+   */
+  pieChartFilterOnSlice(name) {
+    this.testRunner.get(`[data-test-subj="pieSlice-${name}"]`).click()
+  }
+
+  /**
+   * Removes a filters placed on a pie chart visualization with a specific keyword
+   * @param {String} keyword Keyword for the pie chart filter
+   */
+  pieChartRemoveFilter(keyword) {
+    this.testRunner.get(this._generateFilterSearchString(keyword)).click()
+    this.testRunner.get('[data-test-subj="deleteFilter"]').click()
+  }
+
+  /**
+   * Asserts that there exists a certain number of instances of an element
+   * @param {String} selector Selector for element of interest
+   * @param {Number} numElements Number of expected elements
+   */
+  checkElementExists(selector, numElements) {
+    this.testRunner.get(selector).should('be.length', numElements)
+  }
+
+  /**
+   * Asserts that a certain element does not exist
+   * @param {String} selector Selector for element of interest
+   */
+  checkElementDoesNotExist(selector) {
+    this.testRunner.get(selector).should('not.exist')
+  }
+
+  /**
+   * Asserts that the components of a certain element does not exist
+   * @param {String} mainSelector Selector for element of interest
+   * @param {String} componentSelector Selector for subcomponent of interest
+   */
+  checkElementComponentDoesNotExist(mainSelector, componentSelector) {
+    this.testRunner.get(mainSelector).find(componentSelector).should('not.exist')
+  }
+
+  /**
+   * Asserts that each element of a given selector contains a certain value
+   * @param {String} selector Selector for element of interest
+   * @param {Number} numElements Number of expected elements to be returned
+   * @param {String} value Regex value
+   */
+  checkElementContainsValue(selector, numElements, value) {
+    this.testRunner.get(selector).should('be.length', numElements).each(($el) => {
+      this.testRunner.get($el).contains(new RegExp(`^${value}$`))
+    })
+  }
+
+  /**
+   * Asserts that each element of a given selector has components that contain a certain value
+   * @param {String} mainSelector Selector for element of interest
+   * @param {String} componentSelector Selector for subcomponent of interest
+   * @param {Number} numElements Number of expected elements to be returned
+   * @param {String} value Regex value
+   */
+  checkElementComponentContainsValue(mainSelector, componentSelector, numElements, value) {
+    this.testRunner.get(mainSelector).should('be.length', numElements).each(($el) => {
+      this.testRunner.get($el).find(componentSelector).contains(new RegExp(`^${value}$`))
+    })
+  }
+
+  /**
+   * Asserts each value in an array of strings is contained within an element
+   * @param {String} selector Selector for element of interest
+   * @param {Array} value Array of string values
+   */
+  checkValuesExistInComponent(selector, value) {
+    this.testRunner.wrap(value).each((str) => {
+      this.testRunner.get(selector).contains(new RegExp(`^${str}$`))
+    })
+  }
+
+  /**
+   * Asserts each value in an array of strings is not contained within an element
+   * @param {String} selector Selector for element of interest
+   * @param {Array} value Array of string values
+   */
+  checkValuesDoNotExistInComponent(selector, value) {
+    this.testRunner.wrap(value).each((str) => {
+      this.testRunner.get(selector).should('not.contain', new RegExp(`^${str}$`))
+    })
+  }
+}

--- a/common-utils/misc-utils.js
+++ b/common-utils/misc-utils.js
@@ -1,0 +1,47 @@
+export class MiscUtils {
+  constructor(inputTestRunner) {
+    this.testRunner = inputTestRunner;
+  }
+
+  /**
+   * Visit the webpage at a specified path
+   * @param {String} path Path to a webpage
+   */
+  visitPage(path) {
+    this.testRunner.visit(path)
+  }
+  
+  /**
+   * Go to the dashboard list page through the navigation side panel
+   */
+  goToDashboardPage() {
+    this.testRunner.get('[data-test-subj="toggleNavButton"]').click()
+    this.testRunner.get('[data-test-subj="collapsibleNavAppLink"]').contains('Dashboard').click()
+  }
+
+  /**
+   * Create a new dashboard from the dashboard list page
+   * @param {Number} timeout Optional timeout duration
+   */
+  createNewDashboard(timeout = 60000) {
+    this.testRunner.get('[data-test-subj="newItemButton"]', { timeout: timeout }).should('be.visible').click()
+    this.testRunner.get('[data-test-subj="emptyDashboardWidget"]').should('be.visible')
+  }
+
+  /**
+   * Enter a specified query to a query input field
+   * @param {String} query Query string to search on
+   */
+  setQuery(query) {
+    this.testRunner.get('[data-test-subj="queryInput"]').type(`{selectall}${query}`)
+    this.testRunner.get('[data-test-subj="querySubmitButton"]').click()
+  }
+
+  /**
+   * Clear the query input field on the current page
+   */
+  removeQuery() {
+    this.testRunner.get('[data-test-subj="queryInput"]').type('{selectall}{backspace}')
+    this.testRunner.get('[data-test-subj="querySubmitButton"]').click()
+  }
+}

--- a/common-utils/network/test-fixture-handler.js
+++ b/common-utils/network/test-fixture-handler.js
@@ -1,0 +1,92 @@
+export class TestFixtureHandler {
+
+  constructor(inputTestRunner, hostname = 'localhost', port = '9200') {
+      this.testRunner = inputTestRunner;
+      this.hostname = hostname;
+      this.port = port;
+  }
+  
+  /**
+   * Read indices from a file and send to OpenSearch using the create index API
+   * @param {String} filename File path (with its root at the directory containing the cypress.json file)
+   */
+  importJSONMapping(filename) {
+    const parseIndex = ({ index, settings, mappings, aliases }) => {
+    return { index, body: { settings, mappings, aliases } }
+    }
+
+    this.testRunner.readFile(filename, 'utf8').then((str) => {
+      const strSplit = str.split('\n\n')
+      strSplit.forEach((element) => {
+        const json = JSON.parse(element)
+        if (json.type === 'index') {
+          const indexContent = parseIndex(json.value)
+          this.testRunner.request({ method: 'PUT', url: `${this.hostname}:${this.port}/${indexContent.index}`, body: indexContent.body, failOnStatusCode: false }).then((response) => {
+  
+          })
+        }
+      })
+    })
+  }
+
+  /**
+   * Read indices from a file and request for them to be deleted from OpenSearch using the delete index API
+   * @param {String} filename File path (with its root at the directory containing the cypress.json file)
+   */
+  clearJSONMapping(filename) {
+    this.testRunner.readFile(filename, 'utf8').then((str) => {
+      const strSplit = str.split('\n\n')
+      strSplit.forEach((element) => {
+          const json = JSON.parse(element)
+          if (json.type === 'index') {
+            const index = json.value.index
+            this.testRunner.request({ method: 'DELETE', url: `${this.hostname}:${this.port}/${index}`, failOnStatusCode: false }).then((response) => {
+            })
+          }
+      })
+    })
+  }
+
+  /**
+   * Read docs from a file and import them to OpenSearch using the bulk API
+   * @param {String} filename File path (with its root at the directory containing the cypress.json file)
+   * @param {Number} bulkMax Maximum number of combined action and source NDJSONs to send in one bulk API request
+   */
+  importJSONDoc(filename, bulkMax = 1600) {
+    const parseDocument = ({ value: { id, index, source } }) => {
+      const actionData = { index: { _id: id, _index: index } }
+      const oneLineAction = JSON.stringify(actionData).replace('\n', '')
+      const oneLineSource = JSON.stringify(source).replace('\n', '')
+      const bulkOperation = `${oneLineAction}\n${oneLineSource}`
+      return bulkOperation
+    }
+  
+    const sendBulkAPIRequest = (bodyArray, hostname, port) => {
+      this.testRunner.request({ headers: { 'Content-Type': 'application/json' }, method: 'POST', url: `${hostname}:${port}/_bulk`, body: `${bodyArray.join('\n')}\n`, timeout: 30000 }).then((response) => {
+  
+      })
+    }
+
+    this.testRunner.readFile(filename, 'utf8').then((str) => {
+      let readJSONCount = 0
+      const bulkLines = [[]]
+      str.split('\n\n').forEach((element) => {
+        bulkLines[0].push(parseDocument(JSON.parse(element)))
+  
+        readJSONCount++
+        if (readJSONCount % bulkMax === 0) {
+          sendBulkAPIRequest(bulkLines.pop(), this.hostname, this.port)
+          bulkLines.push([])
+        }
+      })
+  
+      if (bulkLines.length > 0) {
+        sendBulkAPIRequest(bulkLines.pop(), this.hostname, this.port)
+      }
+  
+      this.testRunner.request({ method: 'POST', url: `${this.hostname}:${this.port}/_all/_refresh` }).then((response) => {
+  
+      })
+    })
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+export { hello } from "./page-object-model/sample.js"
+
+export { HomePage } from './page-object-model/home-page/home-page.js'
+
+export { HOME_PAGE_ELEMENTS } from './page-object-model/home-page/page-elements.js'
+
+export { DashboardPage } from './page-object-model/dashboard-page/dashboard-page.js'
+
+export { TestFixtureHandler } from './common-utils/network/test-fixture-handler.js'
+
+export { CommonUI } from './common-utils/common-UI/common-UI.js'
+
+export { MiscUtils } from './common-utils/misc-utils.js'
+
+export { LoginPage } from './page-object-model/login-page/login-page.js'

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@opensearch-dashboards-test/opensearch-dashboards-test-library",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opensearch-project/opensearch-dashboards-test-library.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/opensearch-project/opensearch-dashboards-test-library/issues"
+  },
+  "homepage": "https://github.com/opensearch-project/opensearch-dashboards-test-library"
+}

--- a/page-object-model/dashboard-page/dashboard-page.js
+++ b/page-object-model/dashboard-page/dashboard-page.js
@@ -1,0 +1,89 @@
+export class DashboardPage {
+  constructor(inputTestRunner) {
+    this.testRunner = inputTestRunner;
+  }
+  /**
+   * Add saved Dashboard panels
+   * @param {String} keyword Search term for panels of interest
+   * @param {String} type Panel type to search for
+   * @param {Boolean} multiplePages Whether there are multiple pages to iterate through
+   */
+  addDashboardPanels(keyword, type, multiplePages = true) {
+    const replaceSpacesWithDashes = (keyword) => {
+      return keyword.replace(/\s+/g, '-')
+    }
+  
+    const iteratePages = () => {
+      this.testRunner.get('[data-test-subj="pagination-button-next"]').then(($nextBtn) => {
+        this.testRunner.get('[data-test-subj="savedObjectFinderItemList"]').should('be.visible')
+        if ($nextBtn.is(':enabled')) {
+          this.testRunner.wrap($nextBtn).click()
+          this.testRunner.get(`[data-test-subj^="savedObjectTitle${replaceSpacesWithDashes(keyword)}"]`).should('be.visible').each(($button) => {
+            this.testRunner.wrap($button).click()
+            this.testRunner.get('[data-test-subj="toastCloseButton"').click({ multiple: true, force: true })
+          })
+          iteratePages()
+        }
+      })
+    }
+    this.testRunner.get('[data-test-subj="dashboardAddPanelButton"]').should('be.visible').click()
+    this.testRunner.get('[data-test-subj="savedObjectFinderItemList"]').should('be.visible')
+  
+    this.testRunner.get('[data-test-subj="savedObjectFinderFilterButton"]').should('be.visible').click()
+    this.testRunner.get(`[data-test-subj="savedObjectFinderFilter-${type}"]`).should('be.visible').click()
+    this.testRunner.get('[data-test-subj="savedObjectFinderFilterButton"]').should('be.visible').click()
+  
+    this.testRunner.get('[data-test-subj="savedObjectFinderSearchInput"]').should('be.visible').type(keyword)
+  
+    this.testRunner.get(`[data-test-subj^="savedObjectTitle${replaceSpacesWithDashes(keyword)}"]`).should('be.visible').each(($button) => {
+      this.testRunner.wrap($button).click()
+      this.testRunner.get('[data-test-subj="toastCloseButton"').click({ multiple: true, force: true })
+    }).then(() => {
+      if (multiplePages) {
+        this.testRunner.wrap(iteratePages())
+      }
+    })
+    this.testRunner.get('[data-test-subj="euiFlyoutCloseButton"]').click()
+  }
+  
+  /**
+   * Save a dashboard visualization
+   * @param {String} title Field value to select
+   * @param {Boolean} saveAsNew Whether to save as new visualization
+   * @param {Boolean} returnToDashboard Whether to return to the home dashboard
+   */
+  saveDashboardVisualization(title, saveAsNew = false, returnToDashboard = false) {
+    this.testRunner.get('[data-test-subj="visualizeSaveButton"]').click()
+    this.testRunner.get('[data-test-subj="savedObjectTitle"]').type(`{selectall}${title}`)
+    this.testRunner.get('[data-test-subj="saveAsNewCheckbox"]').then(($checkbox) => {
+      if (saveAsNew === false) {
+        this.testRunner.get($checkbox).click()
+      }
+    })
+    this.testRunner.get('[data-test-subj="returnToOriginModeSwitch"]').then(($checkbox) => {
+      if (returnToDashboard === false) {
+        this.testRunner.get($checkbox).click()
+      }
+    })
+    this.testRunner.get('[data-test-subj="confirmSaveSavedObjectButton"]').click()
+  }
+
+  /**
+   * Open the context/options menu for a dashboards visualization given its title name.
+   * CAUTION: if multiple visualizations have the same name, this method will fail
+   * @param {String} panelName Name of the dashboards visualization
+   */
+  openVisualizationContextMenu(panelName) {
+    const removeSpaces = (keyword) => {
+      return keyword.replace(/\s+/g, '')
+    }
+    this.testRunner.get(`[data-test-subj="embeddablePanelHeading-${removeSpaces(panelName)}"]`).find('[data-test-subj="embeddablePanelToggleMenuIcon"]').click()
+  }
+
+  /**
+   * Click on the edit button in a dashboard visualization's context menu
+   */
+  clickEditVisualization() {
+    this.testRunner.get('[data-test-subj="embeddablePanelAction-editPanel"]').click()
+  }
+}

--- a/page-object-model/home-page/home-page.js
+++ b/page-object-model/home-page/home-page.js
@@ -1,0 +1,28 @@
+import { HOME_PAGE_ELEMENTS } from './page-elements'
+
+export class HomePage {
+
+    constructor(inputTestRunner) {
+        this.testRunner = inputTestRunner;
+    }
+
+    open(url) {
+        this.testRunner.visit(url)
+    }
+
+    clickSearchBox() {
+        this.testRunner.get(HOME_PAGE_ELEMENTS.SEARCH_BOX)
+            .click()
+    }
+
+    typeInSearchBox() {
+        this.testRunner.get(HOME_PAGE_ELEMENTS.SEARCH_BOX)
+            .type('amazon')
+    }
+
+    submitSearchQuery() {
+        this.testRunner.get(HOME_PAGE_ELEMENTS.SEARCH_BOX)
+            .type(`{enter}`)
+
+    }
+}

--- a/page-object-model/home-page/page-elements.js
+++ b/page-object-model/home-page/page-elements.js
@@ -1,0 +1,3 @@
+export const HOME_PAGE_ELEMENTS = {
+    SEARCH_BOX: ".gLFyf"
+}

--- a/page-object-model/login-page/login-page-elements.js
+++ b/page-object-model/login-page/login-page-elements.js
@@ -1,0 +1,5 @@
+export const LOGIN_PAGE_ELEMENTS = {
+    USER_NAME_INPUT: '[data-test-subj="user-name"]',
+    PASSWORD_INPUT: '[data-test-subj="password"]',
+    SUBMIT_BUTTON: '[data-test-subj="submit"]'
+}

--- a/page-object-model/login-page/login-page.js
+++ b/page-object-model/login-page/login-page.js
@@ -1,0 +1,19 @@
+import { LOGIN_PAGE_ELEMENTS } from './login-page-elements'
+
+export class LoginPage {
+    constructor(inputTestRunner) {
+        this.testRunner = inputTestRunner;
+    }
+
+    enterUserName(userName) {
+        this.testRunner.get(LOGIN_PAGE_ELEMENTS.USER_NAME_INPUT, { timeout: 60000 }).should('be.visible').type(userName)
+    }
+
+    enterPassword(password) {
+        this.testRunner.get(LOGIN_PAGE_ELEMENTS.PASSWORD_INPUT).should('be.visible').type(password)
+    }
+
+    submit() {
+        this.testRunner.get(LOGIN_PAGE_ELEMENTS.SUBMIT_BUTTON).should('be.visible').click()
+    }
+}

--- a/page-object-model/sample.js
+++ b/page-object-model/sample.js
@@ -1,0 +1,3 @@
+export function hello(message) {
+    console.log('Message is ' + message)
+}

--- a/page-object-model/sample.js
+++ b/page-object-model/sample.js
@@ -1,3 +1,0 @@
-export function hello(message) {
-    console.log('Message is ' + message)
-}


### PR DESCRIPTION
### Description
This change basically ports the Monterey project https://github.com/tianleh/monterey-test-library The PR looks lengthy since it is a package level move. We want to review the new changes on top of the Monterey project which are:

1. rename the NPM scope to avoid using developer names
2. re-publish this repository through `npm publish --access public`
3. update package json file to use the new repository links

 
### Issues Resolved
https://github.com/opensearch-project/opensearch-dashboards-test-library/issues/1
 
### Check List
- [See the Cypress workflows success in https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/2 ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
