### PR TITLE
embed port information into base url

### DIFF
--- a/common-utils/network/test-fixture-handler.js
+++ b/common-utils/network/test-fixture-handler.js
@@ -1,9 +1,8 @@
 export class TestFixtureHandler {
 
-  constructor(inputTestRunner, hostname = 'localhost', port = '9200') {
+  constructor(inputTestRunner, openSearchUrl = 'localhost:9200') {
       this.testRunner = inputTestRunner;
-      this.hostname = hostname;
-      this.port = port;
+      this.openSearchUrl = openSearchUrl;
   }
   
   /**
@@ -21,7 +20,7 @@ export class TestFixtureHandler {
         const json = JSON.parse(element)
         if (json.type === 'index') {
           const indexContent = parseIndex(json.value)
-          this.testRunner.request({ method: 'PUT', url: `${this.hostname}:${this.port}/${indexContent.index}`, body: indexContent.body, failOnStatusCode: false }).then((response) => {
+          this.testRunner.request({ method: 'PUT', url: `${this.openSearchUrl}/${indexContent.index}`, body: indexContent.body, failOnStatusCode: false }).then((response) => {
   
           })
         }
@@ -40,7 +39,7 @@ export class TestFixtureHandler {
           const json = JSON.parse(element)
           if (json.type === 'index') {
             const index = json.value.index
-            this.testRunner.request({ method: 'DELETE', url: `${this.hostname}:${this.port}/${index}`, failOnStatusCode: false }).then((response) => {
+            this.testRunner.request({ method: 'DELETE', url: `${this.openSearchUrl}/${index}`, failOnStatusCode: false }).then((response) => {
             })
           }
       })
@@ -61,8 +60,8 @@ export class TestFixtureHandler {
       return bulkOperation
     }
   
-    const sendBulkAPIRequest = (bodyArray, hostname, port) => {
-      this.testRunner.request({ headers: { 'Content-Type': 'application/json' }, method: 'POST', url: `${hostname}:${port}/_bulk`, body: `${bodyArray.join('\n')}\n`, timeout: 30000 }).then((response) => {
+    const sendBulkAPIRequest = (bodyArray, openSearchUrl) => {
+      this.testRunner.request({ headers: { 'Content-Type': 'application/json' }, method: 'POST', url: `${openSearchUrl}/_bulk`, body: `${bodyArray.join('\n')}\n`, timeout: 30000 }).then((response) => {
   
       })
     }
@@ -75,16 +74,16 @@ export class TestFixtureHandler {
   
         readJSONCount++
         if (readJSONCount % bulkMax === 0) {
-          sendBulkAPIRequest(bulkLines.pop(), this.hostname, this.port)
+          sendBulkAPIRequest(bulkLines.pop(), this.openSearchUrl)
           bulkLines.push([])
         }
       })
   
       if (bulkLines.length > 0) {
-        sendBulkAPIRequest(bulkLines.pop(), this.hostname, this.port)
+        sendBulkAPIRequest(bulkLines.pop(), this.openSearchUrl)
       }
   
-      this.testRunner.request({ method: 'POST', url: `${this.hostname}:${this.port}/_all/_refresh` }).then((response) => {
+      this.testRunner.request({ method: 'POST', url: `${this.openSearchUrl}/_all/_refresh` }).then((response) => {
   
       })
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-dashboards-test/opensearch-dashboards-test-library",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Provides utility functions, page object models, test fixture hanlding for developers to write functional tests for OpenSearch Dashboards and dashboards plugins",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Signed-off-by: Tengda He <tengh@amazon.com>

### Description
embed port information into base url, to allow consistency between OS and OSD endpoint visit convention.
 
### Issues Resolved
#9 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
