### PR TITLE
[Bug] Fix commonUI addFilterRetrySelection to allow multiple values

### DIFF
--- a/common-utils/common-UI/common-UI.js
+++ b/common-utils/common-UI/common-UI.js
@@ -5,8 +5,8 @@ export class CommonUI {
 
   /**
    * Generate a selector string for a filter based on its field attribute.
-   * CAUTION: retrieving the elements associated with the returned selector string 
-   * may produce multiple filters if they all correspond to the same field attribute 
+   * CAUTION: retrieving the elements associated with the returned selector string
+   * may produce multiple filters if they all correspond to the same field attribute
    * @param {String} field Field attribute value of the filter
    * @returns {String}
    */
@@ -85,7 +85,7 @@ export class CommonUI {
    * Attempts to add a specified filter, retrying by reselecting the failed option
    * @param {String} field Field value to select
    * @param {String} operator Operator value to select
-   * @param {String} value Value field input
+   * @param {String | Array<String>} value Value field input
    */
   addFilterRetrySelection(field, operator, value = null, maxRetries = 3) {
     const selectComboBoxInput = (selector, keyword, retry = 0) => {
@@ -107,7 +107,11 @@ export class CommonUI {
     })
 
     if (value != null) {
-      this.testRunner.get('[data-test-subj="filterParams"]').find('input').type(value)
+      if(typeof(value) == 'string'){
+        this.testRunner.get('[data-test-subj="filterParams"]').find('input').type(value)
+      }else{
+        for(let i = 0; i<value.length; i++) this.testRunner.get('[data-test-subj="filterParams"]').find('input').eq(i).type(value[i])
+      }
     }
 
     this.testRunner.get('[data-test-subj="saveFilter"]').click()


### PR DESCRIPTION
### Description
Value is now set to type string or array. Therefore, it won't break any current customer usage. Meanwhile, it could setup multiple values. For 'is between' operation, now we could pass a value pair to setup.

### Issues Resolved
https://github.com/opensearch-project/opensearch-dashboards-test-library/issues/25

### Example
An example is here: 
https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/423/files

In test case `'Should correctly filter for applied time filter on the main timefield'` both single value and a pair of values have been tested.

https://user-images.githubusercontent.com/79961084/207461143-5bce1b9a-2f55-466b-8299-797834ce8817.mov



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
