### PR TITLE
add initial maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,12 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer               | GitHub ID                               | Affiliation |
-| ------------------------ | --------------------------------------- | ----------- |
-| Henri Yandell            | [hyandell](https://github.com/hyandell) | Amazon      |
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)     | Amazon      |
+| Maintainer        | GitHub ID                                           | Affiliation |
+| ----------------- | --------------------------------------------------- | ----------- |
+| Tianle Huang      | [tianleh](https://github.com/tianleh)               | Amazon      |
+| Kawika Avilla     | [kavilla](https://github.com/kavilla)               | Amazon      |
+| Tyler Ohlsen      | [ohltyler](https://github.com/ohltyler)             | Amazon      |
+| Cong Wang         | [CCongWang](https://github.com/CCongWang)           | Amazon      |
+| Manideep Pabba    | [mpabba3003](https://github.com/mpabba3003)         | Amazon      |
+| Ashwin P Chandran | [ashwin-pc](https://github.com/ashwin-pc)           | Amazon      |
+| Peter Zhu         | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
Add initial maintainers. Use the same list from https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/main/MAINTAINERS.md
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-dashboards-test-library/issues/16
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
