### PR TITLE
Chore: Updates setDateRange command to match the new behavior for OUI's date picker

### DIFF
--- a/common-utils/common-UI/common-UI.js
+++ b/common-utils/common-UI/common-UI.js
@@ -23,10 +23,8 @@ export class CommonUI {
   setDateRange(end, start) {
     this.testRunner.get('[data-test-subj="superDatePickerShowDatesButton"]').should('be.visible').click()
 
-    this.testRunner.get('[data-test-subj="superDatePickerstartDatePopoverButton"]').should('be.visible').click()
     this.testRunner.get('[data-test-subj="superDatePickerAbsoluteTab"]').should('be.visible').click()
     this.testRunner.get('[data-test-subj="superDatePickerAbsoluteDateInput"]').should('be.visible').type(`{selectall}${start}`)
-    this.testRunner.get('[data-test-subj="superDatePickerstartDatePopoverButton"]').should('be.visible').click()
 
     this.testRunner.get('[data-test-subj="superDatePickerendDatePopoverButton"]').should('be.visible').click()
     this.testRunner.get('[data-test-subj="superDatePickerAbsoluteTab"]').should('be.visible').click()


### PR DESCRIPTION
### Description
OUI 1.1makes a change that removes the need to click the start date button after clicking show dates. doing so will actually close the popup and fail the test. The change fixes that. 
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
