### PR TITLE
Improve date selection across versions of OUI

### DIFF
--- a/common-utils/common-UI/common-UI.js
+++ b/common-utils/common-UI/common-UI.js
@@ -21,9 +21,31 @@ export class CommonUI {
    * @param {String} end  End datetime to set
    */
   setDateRange(end, start) {
-    this.testRunner.get('[data-test-subj="superDatePickerShowDatesButton"]').should('be.visible').click()
+    /* Find any one of the two buttons that change/open the date picker:
+     *   * if `superDatePickerShowDatesButton` is clicked, it will switch the mode to dates
+     *      * in some versions of OUI, the switch will open the date selection dialog as well
+     *   * if `superDatePickerstartDatePopoverButton` is clicked, it will open the date selection dialog
+     */
+    this.testRunner.get('[data-test-subj="superDatePickerstartDatePopoverButton"], [data-test-subj="superDatePickerShowDatesButton"]')
+        .should('be.visible')
+        .invoke('attr', 'data-test-subj')
+        .then((testId) => {
+          this.testRunner.get(`[data-test-subj="${testId}"]`)
+              .should('be.visible')
+              .click();
+        });
 
-    this.testRunner.get('[data-test-subj="superDatePickerstartDatePopoverButton"]').should('be.visible').click()
+    /* While we surely are in the date selection mode, we don't know if the date selection dialog
+     * is open or not. Looking for a tab and if it is missing, click on the dialog opener.
+     */
+    this.testRunner.get('body').then($body => {
+      if ($body.find('[data-test-subj="superDatePickerAbsoluteTab"]').length === 0) {
+        this.testRunner.get('[data-test-subj="superDatePickerstartDatePopoverButton"]')
+            .should('be.visible')
+            .click();
+      }
+    });
+
     this.testRunner.get('[data-test-subj="superDatePickerAbsoluteTab"]').should('be.visible').click()
     this.testRunner.get('[data-test-subj="superDatePickerAbsoluteDateInput"]').should('be.visible').type(`{selectall}${start}`)
     this.testRunner.get('[data-test-subj="superDatePickerstartDatePopoverButton"]').should('be.visible').click()


### PR DESCRIPTION
### Description
Different versions of OUI provide differing user experiences; this change adds conditional actions to function against the known variants. 
 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
