### PR TITLE
Add import helper function to optimize data uploading time

### DIFF
--- a/common-utils/network/test-fixture-handler.js
+++ b/common-utils/network/test-fixture-handler.js
@@ -97,14 +97,10 @@ export class TestFixtureHandler {
    * @param {string} indexDataPath File path for the actual data
    */
   importJSONDocIfNeeded(index, indexMappingPath, indexDataPath) {
-    let queryString = '';
-    if (typeof index === 'string') {
-      queryString = index;
-    } else if (Array.isArray(index)) {
-      index.forEach(value => queryString += `${value},`);
-    } else {
-      return;
-    }
+    const items = (Array.isArray(index) ? index : [index]);
+    if (items.some(value => typeof value !== 'string')) throw 'Invalid indices';
+    const queryString = items.join(',');
+
     cy.getIndices(queryString).then((response) => {
       if(response.status === 404){
         this.importJSONMapping(indexMappingPath);

--- a/common-utils/network/test-fixture-handler.js
+++ b/common-utils/network/test-fixture-handler.js
@@ -88,4 +88,26 @@ export class TestFixtureHandler {
       })
     })
   }
+
+  /**
+   * Read docs from a file and import them to OpenSearch only when the indices do not already exist
+   * in order to optimize the data uploading time
+   * @param {string, array} index An index or a set of indices 
+   * @param {string} indexMappingPath File path for mapping data
+   * @param {string} indexDataPath File path for the actual data
+   */
+  importJSONDocIfNeeded(index, indexMappingPath, indexDataPath) {
+    let queryString = '';
+    if (typeof index === 'string') {
+      queryString = index;
+    } else {
+      index.forEach(value => queryString += `${value},`);
+    }
+    cy.getIndices(queryString).then((response) => {
+      if(response.status === 404){
+        this.importJSONMapping(indexMappingPath);
+        this.importJSONDoc(indexDataPath);
+      }
+    });
+  }
 }

--- a/common-utils/network/test-fixture-handler.js
+++ b/common-utils/network/test-fixture-handler.js
@@ -100,8 +100,10 @@ export class TestFixtureHandler {
     let queryString = '';
     if (typeof index === 'string') {
       queryString = index;
-    } else {
+    } else if (Array.isArray(index)) {
       index.forEach(value => queryString += `${value},`);
+    } else {
+      return;
     }
     cy.getIndices(queryString).then((response) => {
       if(response.status === 404){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-dashboards-test/opensearch-dashboards-test-library",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-dashboards-test/opensearch-dashboards-test-library",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Provides utility functions, page object models, test fixture handling for developers to write functional tests for OpenSearch Dashboards and plugins",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
### Description
Add a function to read docs from a file and import them to OpenSearch only when the indices do not already exist in order to optimize the data uploading time in cypress tests. 
 
### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/903
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
