### PR TITLE
fix: fully specify imports

### DIFF
--- a/page-object-model/home-page/home-page.js
+++ b/page-object-model/home-page/home-page.js
@@ -1,4 +1,4 @@
-import { HOME_PAGE_ELEMENTS } from './page-elements'
+import { HOME_PAGE_ELEMENTS } from './page-elements.js'
 
 export class HomePage {
 

--- a/page-object-model/login-page/login-page.js
+++ b/page-object-model/login-page/login-page.js
@@ -1,4 +1,4 @@
-import { LOGIN_PAGE_ELEMENTS } from './login-page-elements'
+import { LOGIN_PAGE_ELEMENTS } from './login-page-elements.js'
 
 export class LoginPage {
     constructor(inputTestRunner) {


### PR DESCRIPTION
### Description
In this package, we have a mix of fully specified imports (including .js extension) in our index.js and non-fully specified in two instances of pages. With the cypress v12 upgrade this package is expected to have only fully resolved imports. You can see an example failure caused by this [here](https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/12056312041/job/33618566781?pr=8926).

We can change this in the future with a custom [cypress preprocessor](https://docs.cypress.io/api/node-events/preprocessors-api) in our e2e.js file, but that seemed a bit overkill to me for these two import instances.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
